### PR TITLE
Add initial site settings

### DIFF
--- a/.cloudcannon/initial-site-settings.json
+++ b/.cloudcannon/initial-site-settings.json
@@ -1,0 +1,14 @@
+{
+  "ssg": "eleventy",
+  "build_configuration": {
+    "preserved_paths": "",
+    "environment_variables": [],
+    "config": "",
+    "formats": "",
+    "input": "",
+    "output": "_site",
+    "pathprefix": "",
+    "quiet": false,
+    "manage_plugin_manually": false
+  }
+}


### PR DESCRIPTION
Add .cloudcannon/initial-site-settings.json file. This specifies all the details CloudCannon needs to build the site, so that templates can be loaded directly into CloudCannon and built without asking the using for configuration. In most cases, the default config for the SSG is correct, so this file may only need to specify the SSG it uses.